### PR TITLE
declare variables used in serverBootFunc

### DIFF
--- a/4_wavetables.sc
+++ b/4_wavetables.sc
@@ -47,6 +47,9 @@ Routine({
 (	// to be put to Platform.userConfigDir +/+ "startup.scd"
 
 ~serverBootFunc = { |server|
+
+        var wtsize, wtpaths, wtbuffers;
+	
 	"-----------wavetables begin-----------".postln;	
 
 


### PR DESCRIPTION
The variables need to be declared in order for serverBootFunc to work. Thanks for posting these amazing videos and code!